### PR TITLE
Batchsize limit increased to 64

### DIFF
--- a/GradientTest.py
+++ b/GradientTest.py
@@ -9,8 +9,8 @@ import cupy as cp
 
 # Hyperparameters
 ip_chans, op_chans = 8,16 
-h,w = 128, 128 
-batch_size = 16 
+h,w = 4, 4 
+batch_size = 63 
 G = 12 
 # exp = 3
 CMP = 4


### PR DESCRIPTION
1. Optimize for best blockDims given MAX_THREADS_PER_BLOCK
2. Issue: since max-Z value of blockDims is limited to 64, batch-size is limited to 64.