### PR TITLE
BugFix in pool_ops.py

### DIFF
--- a/GradientTest.py
+++ b/GradientTest.py
@@ -3,14 +3,14 @@ import matplotlib.pyplot as plt
 import torch.nn as nn 
 import torch 
 import random 
-from PRCN import PRCNv1_noconv, PRCNv2_noconv, PRCNv1, PRCNv2, PRCNPTN, FastPRCNPTN
+from PRCN import PRCNPTN, FastPRCNPTN
 from copy import deepcopy 
 import cupy as cp
 
 # Hyperparameters
-ip_chans, op_chans = 8,16 
-h,w = 4, 4 
-batch_size = 63 
+ip_chans, op_chans = 48, 24
+h,w = 32, 32
+batch_size = 64
 G = 12 
 # exp = 3
 CMP = 4
@@ -62,7 +62,7 @@ op2_grad = op2.grad.cpu().detach().numpy()
 op2_val   = op2.cpu().detach().numpy()
 del loss 
 
-print("Forward pass activation equaliy:") 
+print("Forward pass activation equality:") 
 print(torch.allclose(op2,op1))
 print("Backward pass gradient equality:")
 print(torch.allclose(grad1, grad2))


### PR DESCRIPTION
Notes:
1. Due to incorrect division, some parts of the input volume were not being operated on.
2. switched from num_tiles = height / max_tile_dim --> num_tiles=height/max_tile_dim+1. With this fix, now
3. decreased max_tile_dim from 8 --> 4 , this might reduce speed but it still allows us to respect the max blockDim.z limitation (64) and the total number of threads per block limitation (1024).
4. GradientTest.py was giving a false sense of security because we were only testing small spatial input for forward and backward pass equality. As soon as I shifted to larger inputs i.e 32x32, suddenly forward and backward results were different due to (1).
5. After changing (2,3), even with larger inputs (32x32), GradientTest.py passes forward and backward checks.